### PR TITLE
Correct MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 ASP.NET Monsters
+Copyright (c) 2020 Bryan Knox
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Thanks for forking my repo and I hope your NuGet package is well received.

https://github.com/bryanknox/AzureFunctionsOpenIDConnectAuthSample

This is just a correction to the copyright notices in the LICNSE file so that it complies with the MIT license.

In an MIT license, the copyright notice(s) from the forked repo need to be retained as-is, per the text in the MIT License. The copyright notice for this newer repo is then added before the others.

Kind regards.